### PR TITLE
[MEM-575] Add breadcrumbs to navigation

### DIFF
--- a/src/components/organisms/navigation.tsx
+++ b/src/components/organisms/navigation.tsx
@@ -69,7 +69,7 @@ const Navigation = ({ session }: INavigationProps) => {
               } else {
                 return(
                   <BreadcrumbItem key={i}>
-                    <BreadcrumbLink color={`mode.${colorMode}.tertiary`}>
+                    <BreadcrumbLink href={`/${crumb}`} color={`mode.${colorMode}.tertiary`}>
                       {crumb}
                     </BreadcrumbLink>
                   </BreadcrumbItem>

--- a/src/components/organisms/navigation.tsx
+++ b/src/components/organisms/navigation.tsx
@@ -1,12 +1,17 @@
 import React from "react";
 import {
   Icon,
+  Box,
   Flex,
   useColorMode,
   Button,
   LightMode,
   Stack,
   IconButton,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator
 } from "@chakra-ui/core";
 import Project from "../molecules/project";
 import Link from "next/link";
@@ -34,15 +39,33 @@ const Navigation = ({ session }: INavigationProps) => {
         pos="sticky"
         top={8}
       >
-        <Link href="/">
-          <Icon
-            name="Logo"
-            color={`mode.${colorMode}.title`}
-            h={8}
-            w="auto"
-            cursor="pointer"
-          />
-        </Link>
+        <Flex
+          align="center"
+          backgroundColor={`mode.${colorMode}.card`}
+          rounded="sm"
+        >
+          <Link href="/">
+            <Icon
+              name="Logo"
+              color={`mode.${colorMode}.title`}
+              h={8}
+              w="auto"
+              cursor="pointer"
+            />
+          </Link>
+          <Breadcrumb ml={3} mt={2} addSeparator={true}>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="#" color={`mode.${colorMode}.tertiary`}>
+                Example
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbItem isCurrentPage>
+              <BreadcrumbLink color={`mode.${colorMode}.tertiary`} href="#">
+                Another
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          </Breadcrumb>
+        </Flex>
         {!isLeft(session) && (
           <section>
             {isLeft(session.right) ? (

--- a/src/components/organisms/navigation.tsx
+++ b/src/components/organisms/navigation.tsx
@@ -28,7 +28,7 @@ interface INavigationProps {
 const Navigation = ({ session }: INavigationProps) => {
   const { colorMode, toggleColorMode } = useColorMode();
   const router = useRouter()
-  const pathForBreadcrumbs = router.pathname.split("/");
+  const pathForBreadcrumbs = router.asPath.split("/").slice(1);
 
   return (
     <>
@@ -57,13 +57,25 @@ const Navigation = ({ session }: INavigationProps) => {
             />
           </Link>
           <Breadcrumb ml={3} mt={2} addSeparator={true}>
-            {pathForBreadcrumbs.slice(1).map((crumb, i) => (
-              <BreadcrumbItem key={i}>
-                <BreadcrumbLink color={`mode.${colorMode}.tertiary`}>
-                  {crumb}
-                </BreadcrumbLink>
-              </BreadcrumbItem>
-            ))}
+            {pathForBreadcrumbs.map((crumb, i, pathForBreadcrumbs) => {
+              if (pathForBreadcrumbs.length - 1 === i) {
+                return(
+                  <BreadcrumbItem key={i} isCurrentPage>
+                    <BreadcrumbLink color={`mode.${colorMode}.tertiary`}>
+                      {crumb}
+                    </BreadcrumbLink>
+                  </BreadcrumbItem>
+                )
+              } else {
+                return(
+                  <BreadcrumbItem key={i}>
+                    <BreadcrumbLink color={`mode.${colorMode}.tertiary`}>
+                      {crumb}
+                    </BreadcrumbLink>
+                  </BreadcrumbItem>
+                )
+              }
+              })}
           </Breadcrumb>
         </Flex>
         {!isLeft(session) && (

--- a/src/components/organisms/navigation.tsx
+++ b/src/components/organisms/navigation.tsx
@@ -1,25 +1,21 @@
 import React from "react";
 import {
   Icon,
-  Box,
   Flex,
   useColorMode,
-  Button,
-  LightMode,
   Stack,
   IconButton,
   Breadcrumb,
   BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator
+  BreadcrumbLink
 } from "@chakra-ui/core";
 import Project from "../molecules/project";
 import Link from "next/link";
-import { Either, isLeft, isRight } from "fp-ts/lib/Either";
+import { Either, isLeft } from "fp-ts/lib/Either";
 import { ISession } from "@auth0/nextjs-auth0/dist/session/session";
 import { Loading } from "../../utils/hookNeedingFetch";
 import { NotAuthorized } from "../../utils/user";
-import { useRouter } from 'next/router'
+import { useRouter } from "next/router";
 
 interface INavigationProps {
   session: Either<Loading, Either<NotAuthorized, ISession>>;
@@ -27,7 +23,7 @@ interface INavigationProps {
 
 const Navigation = ({ session }: INavigationProps) => {
   const { colorMode, toggleColorMode } = useColorMode();
-  const router = useRouter()
+  const router = useRouter();
   const pathForBreadcrumbs = router.asPath.split("/").slice(1);
 
   return (
@@ -59,23 +55,27 @@ const Navigation = ({ session }: INavigationProps) => {
           <Breadcrumb ml={3} mt={2} addSeparator={true}>
             {pathForBreadcrumbs.map((crumb, i, pathForBreadcrumbs) => {
               if (pathForBreadcrumbs.length - 1 === i) {
-                return(
+                return (
                   <BreadcrumbItem key={i} isCurrentPage>
                     <BreadcrumbLink color={`mode.${colorMode}.tertiary`}>
                       {crumb}
                     </BreadcrumbLink>
                   </BreadcrumbItem>
-                )
+                );
               } else {
-                return(
+                const url = pathForBreadcrumbs.slice(0, i + 1).join("/");
+                return (
                   <BreadcrumbItem key={i}>
-                    <BreadcrumbLink href={`/${crumb}`} color={`mode.${colorMode}.tertiary`}>
+                    <BreadcrumbLink
+                      href={`/${url}`}
+                      color={`mode.${colorMode}.tertiary`}
+                    >
                       {crumb}
                     </BreadcrumbLink>
                   </BreadcrumbItem>
-                )
+                );
               }
-              })}
+            })}
           </Breadcrumb>
         </Flex>
         {!isLeft(session) && (

--- a/src/components/organisms/navigation.tsx
+++ b/src/components/organisms/navigation.tsx
@@ -19,6 +19,7 @@ import { Either, isLeft, isRight } from "fp-ts/lib/Either";
 import { ISession } from "@auth0/nextjs-auth0/dist/session/session";
 import { Loading } from "../../utils/hookNeedingFetch";
 import { NotAuthorized } from "../../utils/user";
+import { useRouter } from 'next/router'
 
 interface INavigationProps {
   session: Either<Loading, Either<NotAuthorized, ISession>>;
@@ -26,6 +27,8 @@ interface INavigationProps {
 
 const Navigation = ({ session }: INavigationProps) => {
   const { colorMode, toggleColorMode } = useColorMode();
+  const router = useRouter()
+  const pathForBreadcrumbs = router.pathname.split("/");
 
   return (
     <>
@@ -54,16 +57,13 @@ const Navigation = ({ session }: INavigationProps) => {
             />
           </Link>
           <Breadcrumb ml={3} mt={2} addSeparator={true}>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="#" color={`mode.${colorMode}.tertiary`}>
-                Example
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbItem isCurrentPage>
-              <BreadcrumbLink color={`mode.${colorMode}.tertiary`} href="#">
-                Another
-              </BreadcrumbLink>
-            </BreadcrumbItem>
+            {pathForBreadcrumbs.slice(1).map((crumb, i) => (
+              <BreadcrumbItem key={i}>
+                <BreadcrumbLink color={`mode.${colorMode}.tertiary`}>
+                  {crumb}
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+            ))}
           </Breadcrumb>
         </Flex>
         {!isLeft(session) && (

--- a/src/components/organisms/navigation.tsx
+++ b/src/components/organisms/navigation.tsx
@@ -52,7 +52,7 @@ const Navigation = ({ session }: INavigationProps) => {
               cursor="pointer"
             />
           </Link>
-          <Breadcrumb ml={3} mt={2} addSeparator={true}>
+          <Breadcrumb ml={3} mt={2} addSeparator={true} color={`mode.${colorMode}.text`}>
             {pathForBreadcrumbs.map((crumb, i, pathForBreadcrumbs) => {
               if (pathForBreadcrumbs.length - 1 === i) {
                 return (


### PR DESCRIPTION
### What's in this PR:
- Dynamic breadcrumbs in the navigation 
- All except current page are linked respectively
- Removed unused imports from `navigation.tsx`

### Design
- Uses default breadcrumb separator from Chakra 
- Accessible and relatively responsive 

_Light mode_
<img width="506" alt="Screen Shot 2020-06-10 at 2 03 53 AM" src="https://user-images.githubusercontent.com/26869552/84212838-39989d80-aabf-11ea-8714-6c6127f66d1a.png">

_Dark mode_
<img width="503" alt="Screen Shot 2020-06-10 at 2 04 02 AM" src="https://user-images.githubusercontent.com/26869552/84212845-3e5d5180-aabf-11ea-918d-4e6f3c6fb003.png">
