### PR TITLE
Remove trailing slash from team url

### DIFF
--- a/src/components/molecules/project.tsx
+++ b/src/components/molecules/project.tsx
@@ -75,7 +75,7 @@ const ProjectSettings = ({ session }: IProjectSettingsProps) => {
           <MenuDivider borderColor={`mode.${colorMode}.icon`} />
           <MenuGroup title="Teams" color={`mode.${colorMode}.title`}>
             {teams.map((team, index) => (
-              <Link href={`/${team.name}/`} key={index}>
+              <Link href={`/${team.name}`} key={index}>
                 <MenuItem
                   color={`mode.${colorMode}.text`}
                   d="flex"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -219,7 +219,7 @@ export default withError<GET_SERVER_SIDE_PROPS_ERROR, ITeamsProps>(
             {allTeams.map((team, index) => (
               <Card
                 key={index}
-                link={`/${team.name}/`}
+                link={`/${team.name}`}
                 linkLabel={`Links to ${team.name}'s dashboard`}
               >
                 <Stack spacing={4} isInline>


### PR DESCRIPTION
The tiniest change to remove the trailing `/` from our links to the team dashboards. That way the breadcrumbs are more consistent throughout the entire app 🍞 

_Before_
<img width="572" alt="Screen Shot 2020-06-10 at 2 28 29 PM" src="https://user-images.githubusercontent.com/26869552/84269750-ef98d180-ab29-11ea-8e34-04b1a3da6221.png">

_After_
<img width="465" alt="Screen Shot 2020-06-10 at 2 49 57 PM" src="https://user-images.githubusercontent.com/26869552/84269770-f7587600-ab29-11ea-929e-f80113d38362.png">