### PR TITLE
mem-981

### DIFF
--- a/src/components/molecules/failureMessage.tsx
+++ b/src/components/molecules/failureMessage.tsx
@@ -11,7 +11,8 @@ import CodeBlock from "../molecules/codeBlock";
 import { ExchangeType } from "../../utils/testLog";
 import ReactMarkdown from "react-markdown";
 import Renderers from "./markdownComponents";
-import prettier from "prettier";
+import prettier from "prettier/standalone";
+import parserGraphql from "prettier/parser-graphql";
 
 type FailureProps = {
   exchange: ExchangeType;
@@ -125,7 +126,10 @@ const FailureMessage = ({
                   : exchange.meta.apiType === "graphql"
                   ? prettier.format(
                       JSON.parse(exchange.request.body)["query"],
-                      { parser: "graphql" }
+                      {
+                        parser: "graphql",
+                        plugins: [parserGraphql],
+                      }
                     )
                   : exchange.request.body}
               </CodeBlock>

--- a/src/components/molecules/failureMessage.tsx
+++ b/src/components/molecules/failureMessage.tsx
@@ -131,7 +131,7 @@ const FailureMessage = ({
                         plugins: [parserGraphql],
                       }
                     )
-                  : exchange.request.body}
+                  : JSON.stringify(JSON.parse(exchange.request.body), null, 2)}
               </CodeBlock>
             </>
           )}

--- a/src/components/molecules/failureMessage.tsx
+++ b/src/components/molecules/failureMessage.tsx
@@ -121,7 +121,7 @@ const FailureMessage = ({
                 }
               >
                 {exchange.meta.apiType === "rest"
-                  ? exchange.request.body
+                  ? JSON.stringify(JSON.parse(exchange.request.body), null, 2)
                   : exchange.meta.apiType === "graphql"
                   ? prettier.format(
                       JSON.parse(exchange.request.body)["query"],

--- a/src/components/molecules/failureMessage.tsx
+++ b/src/components/molecules/failureMessage.tsx
@@ -11,6 +11,7 @@ import CodeBlock from "../molecules/codeBlock";
 import { ExchangeType } from "../../utils/testLog";
 import ReactMarkdown from "react-markdown";
 import Renderers from "./markdownComponents";
+import prettier from "prettier";
 
 type FailureProps = {
   exchange: ExchangeType;
@@ -122,7 +123,10 @@ const FailureMessage = ({
                 {exchange.meta.apiType === "rest"
                   ? exchange.request.body
                   : exchange.meta.apiType === "graphql"
-                  ? JSON.parse(exchange.request.body)["query"]
+                  ? prettier.format(
+                      JSON.parse(exchange.request.body)["query"],
+                      { parser: "graphql" }
+                    )
                   : exchange.request.body}
               </CodeBlock>
             </>


### PR DESCRIPTION
Uses prettier on graphql.
This allows a standard formatting to be used across our display irrespective of changes to the `runr`.
In future iterations, we can find a way to show the original graphql (ie with a small link to copy or download the original request), which will allow people to reproduce the query verbatim.