### PR TITLE
[MEM-1086] Fix alt text of images on Team page

### DIFF
--- a/src/pages/[teamName].tsx
+++ b/src/pages/[teamName].tsx
@@ -682,7 +682,7 @@ export default withError<GET_SERVER_SIDE_PROPS_ERROR, ITeamProps>(
                       }
                       backgroundColor="transparent"
                       icon={<FallbackIcon color={`mode.${colorMode}.icon`} />}
-                      name=""
+                      name={session.user.name`'s uploaded avatar`}
                       h={8}
                       w={8}
                       borderRadius="sm"

--- a/src/pages/[teamName].tsx
+++ b/src/pages/[teamName].tsx
@@ -560,6 +560,7 @@ export default withError<GET_SERVER_SIDE_PROPS_ERROR, ITeamProps>(
                     w={8}
                     borderRadius="sm"
                     mr={4}
+                    alt={`Uploaded logo from ${team.name}`}
                   />
                   <Box>
                     <FormLabel
@@ -681,7 +682,7 @@ export default withError<GET_SERVER_SIDE_PROPS_ERROR, ITeamProps>(
                       }
                       backgroundColor="transparent"
                       icon={<FallbackIcon color={`mode.${colorMode}.icon`} />}
-                      name={session.user.name}
+                      name=""
                       h={8}
                       w={8}
                       borderRadius="sm"


### PR DESCRIPTION
### This smol PR fixes two main issues:

1. The logo avatar was missing an alt text.
1. The images next to the team emails were all being read out as the logged-in user's name. Because they are supplementary to the primary info (the email), I added a blank attribute.