### PR TITLE
Use standard http-types request fields

### DIFF
--- a/src/components/molecules/exchange.tsx
+++ b/src/components/molecules/exchange.tsx
@@ -235,7 +235,7 @@ const ExchangeMessage = ({ command, commands }: ExchangeProps) => {
                         : exchange.request.method.toUpperCase()
                       : exchange.request.method.toUpperCase()}
                   </Text>
-                  <Text fontWeight={600}>{exchange.meta.path}</Text>
+                  <Text fontWeight={600}>{exchange.request.pathname}</Text>
                 </Flex>
                 <AccordionIcon color={`mode.${colorMode}.icon`} />
               </AccordionButton>

--- a/src/pages/[teamName]/[projectName]/[testId].tsx
+++ b/src/pages/[teamName]/[projectName]/[testId].tsx
@@ -189,7 +189,7 @@ const smartItemTestCase = (ct: CommandType, i: number): string =>
           ? gqlOperatorName(NEA.head(a).request.body)
           : NEA.head(a).request.method.toUpperCase() +
             " " +
-            NEA.head(a).meta.path
+            NEA.head(a).request.pathname
     )
   );
 

--- a/src/utils/testLog.ts
+++ b/src/utils/testLog.ts
@@ -6,13 +6,9 @@ import { pipe } from "fp-ts/lib/pipeable";
 // uses httptypes
 
 const exchangeType = t.type({
-  meta: t.intersection([
-    t.type({
-      path: t.string,
-      path_params: t.object,
-    }),
-    t.partial({ apiType: t.string }),
-  ]),
+  meta: t.partial({
+    apiType: t.string
+  }),
   response: t.intersection([
     t.type({
       statusCode: t.Integer,
@@ -22,6 +18,7 @@ const exchangeType = t.type({
   request: t.type({
     body: t.union([t.string, t.undefined]),
     method: t.string,
+    pathname: t.string,
     // headers: t.record(t.string, t.union([t.array(t.string), t.string])),
   }),
 });


### PR DESCRIPTION
The `meta.path` field can be replaced with the standard `request.pathname` field.

The `meta.path_params` field can be replaced with `request.query`, but it's not used so can be removed.

This makes the webapp compatible with the output from test_runner.

Needs to await the fix https://github.com/meeshkan/test_runner/pull/31 in test_runner to populate the `request.pathname` field correctly, and this PR has not been tested locally yet.