### PR TITLE
Support the GraphQL query shorthand syntax

### DIFF
--- a/src/components/molecules/exchange.tsx
+++ b/src/components/molecules/exchange.tsx
@@ -221,10 +221,6 @@ const ExchangeMessage = ({ command, commands }: ExchangeProps) => {
                   <Text fontWeight={600} mr={2}>
                     {exchange.meta.apiType === "graphql"
                       ? JSON.parse(exchange.request.body)["query"].startsWith(
-                          "query"
-                        )
-                        ? "QUERY"
-                        : JSON.parse(exchange.request.body)["query"].startsWith(
                             "mutation"
                           )
                         ? "MUTATION"
@@ -232,7 +228,7 @@ const ExchangeMessage = ({ command, commands }: ExchangeProps) => {
                             "subscription"
                           )
                         ? "SUBSCRIPTION"
-                        : exchange.request.method.toUpperCase()
+                        : "QUERY"
                       : exchange.request.method.toUpperCase()}
                   </Text>
                   <Text fontWeight={600}>{exchange.request.pathname}</Text>

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -7,13 +7,11 @@ import { pipe } from "fp-ts/lib/pipeable";
 import { getTokenFromSessionOrEnv } from "../pages/api/session";
 
 export const gqlOperatorName = (b: string) =>
-  JSON.parse(b)["query"].startsWith("query")
-    ? "QUERY"
-    : JSON.parse(b)["query"].startsWith("mutation")
+  JSON.parse(b)["query"].startsWith("mutation")
     ? "MUTATION"
     : JSON.parse(b)["query"].startsWith("subscription")
     ? "SUBSCRIPTION"
-    : "";
+    : "QUERY";
 
 export const errors = t.type({
   errors: t.array(


### PR DESCRIPTION
In GraphQL the operation name and operation type can be left out as a shorthand for a query. So the query:

```graphql
  query HeroComparison {
    hero {
      name
    }
  }
```

Can also be written as:

```graphql
  {
    hero {
      name
    }
  }
```

This is currently generated by test_runner and as supporting it here makes the code shorter and more correct it makes sense to not require the operation type to be written out.

NOTE: Untested as I don't have Vercel credentials to run the webapp locally.