### PR TITLE
Display project repo as {owner}/{name}

### DIFF
--- a/src/components/Dashboard/settings.tsx
+++ b/src/components/Dashboard/settings.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 type SettingsProps = {
   session: ISession;
   repositoryName: String;
+  repositoryOwner: String;
   teamName: String;
   configured: Boolean;
   repositoryId: Number;
@@ -23,6 +24,7 @@ type SettingsProps = {
 const Settings = ({
   session,
   repositoryName,
+  repositoryOwner,
   teamName,
   configured,
   repositoryId,
@@ -80,7 +82,7 @@ const Settings = ({
       <Stack direction="row" my={2}>
         <Text>Repository:</Text>
         <Text color={`mode.${colorMode}.title`} fontWeight={600}>
-          {`${teamName}/${repositoryName}`}
+          {`${repositoryOwner}/${repositoryName}`}
         </Text>
       </Stack>
 

--- a/src/pages/[teamName]/[projectName].tsx
+++ b/src/pages/[teamName]/[projectName].tsx
@@ -170,6 +170,7 @@ export default withError<GET_SERVER_SIDE_PROPS_ERROR, IProjectWithTeamName>(
           teamName={projectProps.teamName}
           repositoryName={projectProps.name}
           repositoryId={projectProps.repository.id}
+          repositoryOwner={projectProps.repository.owner}
           configured={projectProps.configuration ? true : false}
         />
         <Premium


### PR DESCRIPTION
- Project repo should be displayed as `${repoOwner}/${repoName}` instead of `${teamName}/${repoName}`.